### PR TITLE
fix: removed postgre DB username var that wasn't in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Jira is configured by default to assume the internal dependencies that are used 
 #### Database
 
 - A Postgres database is running on port `5432` and accessible to the cluster via the `JIRA_DB_ENDPOINT` Zarf var.
-- This database can be logged into via the username configured with the Zarf var `JIRA_DB_USERNAME`. Default is `jira.jira`
+- This database can be logged into via the username & password given in the postgre connection secret (see `values/common-values.yaml`).
 - This database instance has a psql database created matching what is defined in the Zarf var `JIRA_DB_NAME`. Default is `jiradb`
 - The user has read/write access to the above mentioned database
 - Create `jira-postgres` service in `jira` namespace that points to the psql database

--- a/bundle/uds-config.yaml
+++ b/bundle/uds-config.yaml
@@ -1,6 +1,3 @@
-shared:
-  JIRA_DB_USERNAME: "jira.jira"
-
 variables:
   jira:
     jira_db_endpoint: "pg-cluster.postgres.svc.cluster.local"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -9,8 +9,6 @@ metadata:
 variables:
   - name: JIRA_DB_NAME
     default: "jiradb"
-  - name: JIRA_DB_USERNAME
-    default: "jira"
   - name: JIRA_DB_ENDPOINT
     default: "postgres"
   - name: DOMAIN


### PR DESCRIPTION
The credentials are provided via a secret named in the values file instead. At no point is the removed zarf var referenced except where consumers of the package might see it and use it not knowing it doesn't connect to anything.