### PR TITLE
fix: backport nutanix bundle improvements

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -63,10 +63,10 @@ spec:
         remoteNamespace: {{ .Values.postgres.namespace | quote }}
         remoteSelector:
           {{ .Values.postgres.selector | toYaml | nindent 10 }}
-        port: {{ .Values.postgres.port }}
         {{- else }}
         remoteGenerated: Anywhere
         {{- end }}
+        port: {{ .Values.postgres.port }}
         description: "Jira Postgres"
 
       # Custom rules for unanticipated scenarios

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -47,12 +47,6 @@ spec:
         port: 80
         targetPort: 8080
     allow:
-      - direction: Ingress
-        remoteGenerated: IntraNamespace
-
-      - direction: Egress
-        remoteGenerated: IntraNamespace
-
       - direction: Egress
         remoteNamespace: keycloak
         remoteSelector:

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -57,6 +57,13 @@ spec:
         description: "SSO Internal"
 
       - direction: Egress
+        remoteGenerated: Anywhere
+        selector:
+          app.kubernetes.io/name: jira
+        port: 443
+        description: "SSO External"
+
+      - direction: Egress
         selector:
           app.kubernetes.io/name: jira
         {{- if .Values.postgres.internal }}

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -63,13 +63,6 @@ spec:
         description: "SSO Internal"
 
       - direction: Egress
-        remoteGenerated: Anywhere
-        selector:
-          app.kubernetes.io/name: jira
-        port: 443
-        description: "SSO External"
-
-      - direction: Egress
         selector:
           app.kubernetes.io/name: jira
         {{- if .Values.postgres.internal }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,10 +5,10 @@ postgres:
   internal: true
   selector:
     cluster-name: pg-cluster
-  username: jira
-  password: ""
   namespace: postgres
   port: 5432
+  username: "###ZARF_VAR_JIRA_DB_USERNAME###"
+  password: "###ZARF_VAR_JIRA_DB_PASSWORD###"
 
 sso:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,8 +7,8 @@ postgres:
     cluster-name: pg-cluster
   namespace: postgres
   port: 5432
-  username: "###ZARF_VAR_JIRA_DB_USERNAME###"
-  password: "###ZARF_VAR_JIRA_DB_PASSWORD###"
+  username: "jira"
+  password: ""
 
 sso:
   enabled: true

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -29,6 +29,7 @@ tasks:
       - task: create:package
         with:
           options: "--skip-sbom"
+          architecture: amd64
 
   - name: create-test-bundle
     description: Create a local UDS Jira bundle with dependencies

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -13,6 +13,12 @@ variables:
     default: "postgres"
   - name: DOMAIN
     default: "uds.dev"
+  - name: JIRA_DB_PASSWORD
+    description: "Password will be added to jira-postgres secret and loaded in for connection credentials."
+    default: "replace-me"
+  - name: JIRA_DB_USERNAME
+    description: "Username will be added to jira-postgres secret and loaded in for connection credentials."
+    default: "replace-me"
 
 components:
   - name: jira

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -13,12 +13,6 @@ variables:
     default: "postgres"
   - name: DOMAIN
     default: "uds.dev"
-  - name: JIRA_DB_PASSWORD
-    description: "Password will be added to jira-postgres secret and loaded in for connection credentials."
-    default: "replace-me"
-  - name: JIRA_DB_USERNAME
-    description: "Username will be added to jira-postgres secret and loaded in for connection credentials."
-    default: "replace-me"
 
 components:
   - name: jira


### PR DESCRIPTION
We created an additional package in the nutanix bundle to add a few things to Jira. I've backported those improvements in this PR and restricted the network policies a bit.

Changes:
~~1. Removed the egress anywhere on port 443 policy - unnecessary.~~
2. Removed intranamespace permissions not needed (until clustering).
3. Added Zarf variables so I can either override the name of the postgre cred secret to a secret provided by someone else (as is the case in the test bundle) or provide the creds in a uds-config.yaml file to be put in the default-named secret.
4. Made the postgre port part of the egress rule regardless of whether or not the DB was cluster internal.
5. Fixed a UDS task by making the architecture hard-coded.

Testing:
- I built this locally and deployed it with my nutanix bundle to confirm the zarf vars are correct.
- It also worked as part of my nutanix bundle.
- Additionally the CI pipeline passed.