### PR TITLE
fix: remove playwright image from package deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,7 @@
         "git-tags"
       ],
       "matchPackageNames": [
+        "!/^mcr\\.microsoft\\.com\\/playwright$/",
         "!/bitnami/jmx-exporter/",
         "!/registry1.dso.mil/ironbank/opensource/prometheus/jmx-exporter/"
       ]


### PR DESCRIPTION
## Description

Removes the playwright image from package deps which will add it to the support deps alongside its package version

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
